### PR TITLE
Add an OpenTracing badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # phpkin
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square "Software License")](LICENSE)
-[![Latest Stable Version](https://img.shields.io/packagist/v/whitemerry/phpkin.svg?style=flat-square&label=stable "Latest Stable Version")](https://packagist.org/packages/whitemerry/phpkin)
+[![Latest Stable Version](https://img.shields.io/packagist/v/whitemerry/phpkin.svg?style=flat-square&label=stable "Latest Stable Version")](https://packagist.org/packages/whitemerry/phpkin) [![OpenTracing Badge](https://img.shields.io/badge/OpenTracing-enabled-blue.svg)](http://opentracing.io)
 
 First ***production ready***, simple and full Zipkin implementation without dependencies.
 


### PR DESCRIPTION
__Super happy to see this project contributing to the OpenTracing community! 🎉__

This tiny PR adds an OpenTracing badge to your README.md. The badge is a one-click way for people to learn more about tracing and also show our love for you! 

example: [![OpenTracing Badge](https://img.shields.io/badge/OpenTracing-enabled-blue.svg)](http://opentracing.io)

If you have any questions, please join our [gitter channel](https://gitter.im/opentracing/public).

// Pierre with the OpenTracing team