### PR TITLE
Fix zipkin_timestamp() on 32-bit PHP builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,15 +64,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction --no-progress
+
+      # vendor/ holds only PHP sources, so building it on the amd64 host and
+      # executing it with the 32-bit interpreter is safe. It also keeps
+      # Composer out of the container, which ships without unzip.
       - name: Run tests on 32-bit PHP
         run: |
           docker run --rm --platform linux/386 \
             --volume "$PWD:/app" --workdir /app \
             php:8.3-cli sh -c '
               set -e
-              php -r "echo \"PHP_INT_SIZE=\", PHP_INT_SIZE, PHP_EOL;"
-              curl -sS https://getcomposer.org/installer \
-                | php -- --install-dir=/usr/local/bin --filename=composer
-              composer update --prefer-dist --no-interaction --no-progress
+              php -r "if (PHP_INT_SIZE !== 4) {
+                  fwrite(STDERR, \"expected a 32-bit build, got PHP_INT_SIZE=\" . PHP_INT_SIZE . \"\n\");
+                  exit(1);
+              }"
               vendor/bin/phpunit
             '

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,3 +51,28 @@ jobs:
 
       - name: Run tests
         run: vendor/bin/phpunit
+
+  # Zipkin timestamps are 16 digits, which overflows a 32-bit int. php.net
+  # shipped x86 as the default Windows build for years, so that is where users
+  # hit it (see issue #18). linux/386 runs natively on the amd64 runners, so
+  # this needs no emulation.
+  tests-32bit:
+    name: PHP 8.3 (32-bit)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run tests on 32-bit PHP
+        run: |
+          docker run --rm --platform linux/386 \
+            --volume "$PWD:/app" --workdir /app \
+            php:8.3-cli sh -c '
+              set -e
+              php -r "echo \"PHP_INT_SIZE=\", PHP_INT_SIZE, PHP_EOL;"
+              curl -sS https://getcomposer.org/installer \
+                | php -- --install-dir=/usr/local/bin --filename=composer
+              composer update --prefer-dist --no-interaction --no-progress
+              vendor/bin/phpunit
+            '

--- a/src/AnnotationBlock.php
+++ b/src/AnnotationBlock.php
@@ -23,12 +23,12 @@ class AnnotationBlock
     protected $endpoint;
 
     /**
-     * @var int
+     * @var string
      */
     protected $startTimestamp;
 
     /**
-     * @var int
+     * @var string
      */
     protected $endTimestamp;
 
@@ -37,8 +37,8 @@ class AnnotationBlock
      * (Builds 2 annotations)
      *
      * @param $endpoint Endpoint
-     * @param $startTimestamp int
-     * @param $endTimestamp int Default now
+     * @param $startTimestamp string
+     * @param $endTimestamp string Default now
      * @param $type string Default CLIENT
      */
     public function __construct($endpoint, $startTimestamp, $endTimestamp = null, $type = AnnotationBlock::CLIENT)
@@ -52,7 +52,11 @@ class AnnotationBlock
     /**
      * Duration for span
      *
-     * @return int
+     * Timestamps are wider than a 32-bit int, so on those builds the
+     * subtraction produces a float. It stays exact: the difference is far
+     * below the 2^53 a float represents without loss.
+     *
+     * @return int|float
      */
     public function getDuration()
     {
@@ -62,7 +66,7 @@ class AnnotationBlock
     /**
      * Timestamp for span
      *
-     * @return int
+     * @return string
      */
     public function getStartTimestamp()
     {
@@ -131,7 +135,7 @@ class AnnotationBlock
      * Valid and set timestamp
      *
      * @param $field string
-     * @param $timestamp int
+     * @param $timestamp string
      * @param $now bool
      *
      * @throws \InvalidArgumentException

--- a/src/functions.php
+++ b/src/functions.php
@@ -4,11 +4,20 @@ if (!function_exists('zipkin_timestamp')) {
     /**
      * http://zipkin.io/pages/instrumenting.html#communicating-trace-information#timestamps-and-duration
      *
-     * @return int Current Unix timestamp in microseconds
+     * The value has 16 digits, which does not fit in an int on 32-bit builds,
+     * so it is returned as a numeric string. Treat it as opaque: subtracting
+     * from it degrades to float there and stops being a valid timestamp.
+     *
+     * @return string Current Unix timestamp in microseconds
      */
     function zipkin_timestamp()
     {
-        return intval(microtime(true) * 1000 * 1000);
+        list($fraction, $seconds) = explode(' ', microtime());
+
+        // microtime() always renders the fraction as "0." followed by eight
+        // digits, so slicing six of them preserves the leading zeros that
+        // concatenating an int would drop.
+        return $seconds . substr($fraction, 2, 6);
     }
 }
 

--- a/tests/AnnotationBlockTestCase.php
+++ b/tests/AnnotationBlockTestCase.php
@@ -20,15 +20,17 @@ class AnnotationBlockTestCase extends TestCase
         // given
         $endpoint = new Endpoint('squash', '8.8.8.8', '10');
         $duration = 1000;
-        $endTimestamp = zipkin_timestamp();
-        $startTimestamp = $endTimestamp - $duration;
+        // Fixed, because a timestamp is too wide for int arithmetic on 32-bit.
+        $startTimestamp = '1500000000000000';
+        $endTimestamp = '1500000000001000';
 
         // when
         $annotationBlock = new AnnotationBlock($endpoint, $startTimestamp, $endTimestamp);
         $output = $annotationBlock->toArray();
 
         // then
-        $this->assertSame($duration, $annotationBlock->getDuration());
+        // Not assertSame: the difference is a float on 32-bit builds.
+        $this->assertEquals($duration, $annotationBlock->getDuration());
         $this->assertSame($startTimestamp, $annotationBlock->getStartTimestamp());
         $this->assertCount(2, $output);
         foreach ($output as $element) {
@@ -46,15 +48,16 @@ class AnnotationBlockTestCase extends TestCase
         // given
         $endpoint = new Endpoint('pat', '8.8.4.4', '1024');
         $duration = 2048;
-        $endTimestamp = zipkin_timestamp();
-        $startTimestamp = $endTimestamp - $duration;
+        $startTimestamp = '1500000000000000';
+        $endTimestamp = '1500000000002048';
         $type = AnnotationBlock::SERVER;
 
         // when
         $annotationBlock = new AnnotationBlock($endpoint, $startTimestamp, $endTimestamp, $type);
 
         // then
-        $this->assertSame($duration, $annotationBlock->getDuration());
+        // Not assertSame: the difference is a float on 32-bit builds.
+        $this->assertEquals($duration, $annotationBlock->getDuration());
     }
 
     /**

--- a/tests/FunctionsTestCase.php
+++ b/tests/FunctionsTestCase.php
@@ -1,0 +1,39 @@
+<?php
+namespace whitemerry\phpkin\tests;
+
+/**
+ * Class FunctionsTestCase
+ *
+ * @author Piotr Bugaj <whitemerry@outlook.com>
+ * @package whitemerry\phpkin\tests
+ */
+class FunctionsTestCase extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGenerateAcceptableTimestamp()
+    {
+        // when
+        $timestamp = zipkin_timestamp();
+
+        // then
+        $this->assertTrue(is_zipkin_timestamp($timestamp));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGenerateCurrentTimeInMicroseconds()
+    {
+        // given
+        // A float holds the value on every platform, unlike an int on 32-bit.
+        $now = microtime(true) * 1000 * 1000;
+
+        // when
+        $timestamp = (float) zipkin_timestamp();
+
+        // then
+        $this->assertLessThan(1000 * 1000, abs($timestamp - $now));
+    }
+}

--- a/tests/Mocker.php
+++ b/tests/Mocker.php
@@ -54,7 +54,7 @@ class Mocker
     {
         return new AnnotationBlock(
             static::getEndpoint(),
-            zipkin_timestamp() - 1000
+            zipkin_timestamp()
         );
     }
 }


### PR DESCRIPTION
Closes #18.

## Root cause

`zipkin_timestamp()` returned `intval(microtime(true) * 1000 * 1000)`. A microsecond Unix timestamp is ~1.75×10^15, far past the 2147483647 that `PHP_INT_MAX` holds on a **32-bit build**, so the float was out of range and `intval()` returned garbage. `is_zipkin_timestamp()` rejected it (`ctype_digit` + `strlen === 16`) and `AnnotationBlock::setTimestamp()` threw `must be generated by zipkin_timestamp()`.

This is a 32-bit bug, not a Windows API bug — 32-bit Linux fails identically. It was reported as Windows because php.net shipped x86 as the default Windows build for years.

The reporter's workaround pinpoints the mechanism: it reads the exact same clock (`microtime()` and `microtime(true)` are one `gettimeofday` call in `ext/standard/microtime.c`) and differs only in never converting to `int`. Any theory where the clock itself misbehaves on Windows would break their version too.

## The fix

Build the value from `microtime()`'s string parts so it never passes through an `int`, and return it as a numeric string — the approach from the ticket, with `explode(' ', ...)` in place of the hardcoded offsets `11`/`2`, which assume seconds are always 10 digits and the fraction always has exactly 8 places.

```php
list($fraction, $seconds) = explode(' ', microtime());

return $seconds . substr($fraction, 2, 6);
```

Slicing 6 digits out of the fixed-width `"0."` + 8 digits keeps the leading zeros that concatenating an int would drop. `%.8F` cannot round the fraction up to `"1.00000000"` and cost a second, because `tv_usec` maxes at 999999.

**Zipkin accepts the quoted number.** `V1JsonSpanReader` reads `timestamp` and `duration` via `nextLong()`, which delegates to Gson's `JsonReader` ([`JsonCodec.java:37`](https://github.com/openzipkin/zipkin/blob/master/zipkin/src/main/java/zipkin2/internal/JsonCodec.java)), and Gson parses a double-quoted token with `Long.parseLong()` ([`JsonReader.java:1095-1106`](https://github.com/google/gson/blob/main/gson/src/main/java/com/google/gson/stream/JsonReader.java)).

## Consequences

A timestamp is now **opaque** — subtracting from one degrades to float on 32-bit and stops validating. Nothing in `src/` or the examples ever did, but the tests did, so they use fixed values instead.

`getDuration()` subtracts internally and so returns a float on 32-bit. It is deliberately **not** cast back to `int`: a span longer than ~36 minutes exceeds a 32-bit int, so the cast would reintroduce the very overflow this PR removes. The float stays exact (differences are far below 2^53), and Gson accepts a lossless float for an int64 field ([`JsonReader.java:1124-1127`](https://github.com/google/gson/blob/main/gson/src/main/java/com/google/gson/stream/JsonReader.java)).

## Verification

Nothing in the matrix exercised a 32-bit build, so this added a `linux/386` job (it runs natively on the amd64 runners, no emulation). It asserts `PHP_INT_SIZE === 4` first, so it cannot pass vacuously if the platform flag is ever ignored. `vendor/` is built on the host because the image ships without unzip.

**Before the fix** — 6/6 64-bit jobs green, 32-bit red:

```
EEF......FF........E                                              20 / 20 (100%)

1) AnnotationBlockTestCase::shouldCreate
InvalidArgumentException: startTimestamp must be generated by zipkin_timestamp()

2) FunctionsTestCase::shouldGenerateAcceptableTimestamp
Failed asserting that false is true.

Tests: 20, Errors: 3, Failures: 3.
```

`shouldFailOnType` is the telling one: it passes `zipkin_timestamp()` in with no arithmetic and still gets `startTimestamp must be generated by zipkin_timestamp()` — the generator itself, not a test artifact.

**After the fix** — 7/7 green, including 32-bit:

```
....................                                              20 / 20 (100%)

OK (20 tests, 62 assertions)
```
