### PR TITLE
feat: expose collected spans on Tracer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Vagrantfile
 # Unit tests
 composer.lock
 vendor/
+.phpunit.result.cache
 log/
 build/
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,33 @@ Compatible with both front and back-end applications and respects B3 Propagation
 $ composer require whitemerry/phpkin
 ```
 
+## Upgrading to 2.0
+`Tracer` used to serialize each `Span` the moment it was added. It now keeps the `Span` objects and serializes them once, in `trace()`, which is what makes `getSpans()` possible. What Zipkin receives is unchanged, but three things behave differently.
+
+#### `addSpan()` only accepts `Span`
+Passing anything else throws `InvalidArgumentException`. Serialization used to happen inside `addSpan()`, so any object with a `toArray()` method quietly worked:
+```php
+// Worked in 1.x by accident, throws in 2.0
+$tracer->addSpan($myOwnSpanClass);
+```
+If you have such a class, extend `Span` or build a real `Span` from it.
+
+#### Spans are serialized at `trace()` time
+Anything you change on a `Span` after adding it now ends up in the trace. Sharing one `Metadata` instance between spans is the case that bites, because `Metadata::set()` appends:
+```php
+$metadata = new Metadata();
+
+$metadata->set(Metadata::HTTP_PATH, '/first');
+$tracer->addSpan(new Span($firstId, 'First', $firstAnnotations, $metadata));
+
+$metadata->set(Metadata::HTTP_PATH, '/second');
+$tracer->addSpan(new Span($secondId, 'Second', $secondAnnotations, $metadata));
+```
+In 1.x the first span reported one annotation and the second reported two. In 2.0 both report both. Give each `Span` its own `Metadata` to keep the old result.
+
+#### `Tracer::$spans` holds `Span` objects
+Only relevant if you extend `Tracer` and read the protected property - it used to hold arrays. Use `getSpans()` where you can, and call `toArray()` yourself if you need the serialized form.
+
 ## Documentation
 
 #### Short implementation information

--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ And add to tracer
 $tracer->addSpan($span);
 ```
 
+#### Reading spans back
+Spans stay on the tracer, so you can inspect them - handy in tests or when you need to report them somewhere else:
+```php
+foreach ($tracer->getSpans() as $span) {
+    $data = $span->toArray();
+}
+```
+The span describing the trace itself is built by `trace()` (its end timestamp is not known before that), so call `getSpans()` after `trace()` to get the complete set.
+When the trace is not sampled nothing is collected and `getSpans()` stays empty.
+
 #### Calling tracer statically
 You can get access to tracer statically, in every place of your project, just init TracerProxy:
 ```php
@@ -134,6 +144,7 @@ TracerProxy::init($tracer);
 Now you have access to methods like:
 ```php
 TracerProxy::addSpan($span);
+TracerProxy::getSpans();
 TracerProxy::trace();
 ```
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ foreach ($tracer->getSpans() as $span) {
 The span describing the trace itself is built by `trace()` (its end timestamp is not known before that), so call `getSpans()` after `trace()` to get the complete set.
 When the trace is not sampled nothing is collected and `getSpans()` stays empty.
 
+Spans are serialized once, by `trace()`. Anything you change on a `Span` after `addSpan()` ends up in the trace - including a `Metadata` instance shared between spans, which will report every annotation set on it, not only the ones set before that span was added. Give each `Span` its own `Metadata` if you don't want that.
+
 #### Calling tracer statically
 You can get access to tracer statically, in every place of your project, just init TracerProxy:
 ```php

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -87,6 +87,10 @@ class Tracer
     /**
      * Adds Span to trace
      *
+     * The Span is kept as given and serialized by trace(), so anything changed
+     * on it afterwards - including a Metadata instance it shares with another
+     * Span - ends up in the trace.
+     *
      * @param $span Span
      *
      * @throws \InvalidArgumentException

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -88,14 +88,34 @@ class Tracer
      * Adds Span to trace
      *
      * @param $span Span
+     *
+     * @throws \InvalidArgumentException
      */
     public function addSpan($span)
     {
+        if (!($span instanceof Span)) {
+            throw new \InvalidArgumentException('$span must be instance of Span');
+        }
+
         if (!TracerInfo::isSampled()) {
             return;
         }
 
-        $this->spans[] = $span->toArray();
+        $this->spans[] = $span;
+    }
+
+    /**
+     * Spans collected so far
+     *
+     * The span describing the trace itself is built by trace(), because its
+     * end timestamp is not known before that. Call this after trace() to get
+     * the complete set. Empty when the trace is not sampled.
+     *
+     * @return Span[]
+     */
+    public function getSpans()
+    {
+        return $this->spans;
     }
 
     /**
@@ -113,7 +133,22 @@ class Tracer
         }
 
         $this->addTraceSpan($unsetParentId);
-        $this->logger->trace($this->spans);
+        $this->logger->trace($this->spansToArray());
+    }
+
+    /**
+     * Converts Spans to arrays
+     *
+     * @return array
+     */
+    protected function spansToArray()
+    {
+        $spans = array();
+        foreach ($this->spans as $span) {
+            $spans[] = $span->toArray();
+        }
+
+        return $spans;
     }
 
     /**

--- a/src/TracerProxy.php
+++ b/src/TracerProxy.php
@@ -36,6 +36,17 @@ class TracerProxy
     }
 
     /**
+     * @see Tracer::getSpans()
+     *
+     * @return Span[]
+     */
+    public static function getSpans()
+    {
+        static::checkInstance();
+        return static::$instance->getSpans();
+    }
+
+    /**
      * @see Tracer::trace()
      */
     public static function trace()

--- a/tests/SpyLogger.php
+++ b/tests/SpyLogger.php
@@ -1,0 +1,46 @@
+<?php
+namespace whitemerry\phpkin\tests;
+
+use whitemerry\phpkin\Logger\Logger;
+
+/**
+ * Class SpyLogger
+ * Captures what Tracer hands to the logger
+ *
+ * @author Piotr Bugaj <whitemerry@outlook.com>
+ * @package whitemerry\phpkin\tests
+ */
+class SpyLogger implements Logger
+{
+    /**
+     * @var array|null
+     */
+    protected $spans;
+
+    /**
+     * SpyLogger constructor.
+     *
+     * @param $options array
+     */
+    public function __construct($options = array())
+    {
+    }
+
+    /**
+     * @param $spans array
+     */
+    public function trace($spans)
+    {
+        $this->spans = $spans;
+    }
+
+    /**
+     * Spans received from Tracer
+     *
+     * @return array|null
+     */
+    public function getTracedSpans()
+    {
+        return $this->spans;
+    }
+}

--- a/tests/TracerProxyTestCase.php
+++ b/tests/TracerProxyTestCase.php
@@ -1,0 +1,37 @@
+<?php
+namespace whitemerry\phpkin\tests;
+
+use whitemerry\phpkin\Span;
+use whitemerry\phpkin\Tracer;
+use whitemerry\phpkin\TracerProxy;
+
+/**
+ * Class TracerProxyTestCase
+ *
+ * @author Piotr Bugaj <whitemerry@outlook.com>
+ * @package whitemerry\phpkin\tests
+ */
+class TracerProxyTestCase extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldExposeSpansOfTracer()
+    {
+        // given
+        $tracer = new Tracer('hut', Mocker::getEndpoint(), new SpyLogger());
+        TracerProxy::init($tracer);
+
+        $span = new Span(
+            Mocker::getIdentifier(),
+            'plaster',
+            Mocker::getAnnotationBlock()
+        );
+
+        // when
+        TracerProxy::addSpan($span);
+
+        // then
+        $this->assertSame(array($span), TracerProxy::getSpans());
+    }
+}

--- a/tests/TracerTestCase.php
+++ b/tests/TracerTestCase.php
@@ -1,0 +1,115 @@
+<?php
+namespace whitemerry\phpkin\tests;
+
+use whitemerry\phpkin\Span;
+use whitemerry\phpkin\Tracer;
+
+/**
+ * Class TracerTestCase
+ *
+ * @author Piotr Bugaj <whitemerry@outlook.com>
+ * @package whitemerry\phpkin\tests
+ */
+class TracerTestCase extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldExposeAddedSpans()
+    {
+        // given
+        $tracer = new Tracer('hut', Mocker::getEndpoint(), new SpyLogger());
+        $span = new Span(
+            Mocker::getIdentifier(),
+            'plaster',
+            Mocker::getAnnotationBlock()
+        );
+
+        // when
+        $tracer->addSpan($span);
+
+        // then
+        $this->assertSame(array($span), $tracer->getSpans());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSerializeSpansForLogger()
+    {
+        // given
+        $logger = new SpyLogger();
+        $tracer = new Tracer('hut', Mocker::getEndpoint(), $logger);
+        $span = new Span(
+            Mocker::getIdentifier(),
+            'plaster',
+            Mocker::getAnnotationBlock()
+        );
+        $tracer->addSpan($span);
+
+        // when
+        $tracer->trace();
+
+        // then
+        $traced = $logger->getTracedSpans();
+        $this->assertSame($span->toArray(), $traced[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAppendTraceSpanOnTrace()
+    {
+        // given
+        $tracer = new Tracer('hut', Mocker::getEndpoint(), new SpyLogger());
+        $tracer->addSpan(new Span(
+            Mocker::getIdentifier(),
+            'plaster',
+            Mocker::getAnnotationBlock()
+        ));
+
+        // when
+        $this->assertCount(1, $tracer->getSpans());
+        $tracer->trace();
+
+        // then
+        $spans = $tracer->getSpans();
+        $this->assertCount(2, $spans);
+
+        $traceSpan = $spans[1]->toArray();
+        $this->assertSame('hut', $traceSpan['name']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotCollectSpansWhenNotSampled()
+    {
+        // given
+        $tracer = new Tracer('hut', Mocker::getEndpoint(), new SpyLogger(), false);
+
+        // when
+        $tracer->addSpan(new Span(
+            Mocker::getIdentifier(),
+            'plaster',
+            Mocker::getAnnotationBlock()
+        ));
+
+        // then
+        $this->assertSame(array(), $tracer->getSpans());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldFailOnSpan()
+    {
+        // given
+        $this->expectExceptionWithMessage('InvalidArgumentException', '$span');
+
+        $tracer = new Tracer('hut', Mocker::getEndpoint(), new SpyLogger());
+
+        // then
+        $tracer->addSpan('plaster');
+    }
+}

--- a/tests/TracerTestCase.php
+++ b/tests/TracerTestCase.php
@@ -97,6 +97,10 @@ class TracerTestCase extends TestCase
 
         // then
         $this->assertSame(array(), $tracer->getSpans());
+
+        // TracerInfo keeps 'sampled' in a static and phpunit.xml does not back
+        // static attributes up, so hand the next test a sampled trace
+        Mocker::initTracer();
     }
 
     /**


### PR DESCRIPTION
Closes #17.

`Tracer` serialized every `Span` the moment it was added, so the spans it held were unreachable arrays behind a `protected` property — and the `@var Span[]` docblock on that property was simply wrong.

This keeps the `Span` objects and converts them once, in `trace()`, right before they reach the logger. `getSpans()` returns them, on `Tracer` and through `TracerProxy`.

### The logger payload is unchanged

`AnnotationBlock` and `Endpoint` are immutable after construction, so serializing later produces byte-identical output for spans that are not touched after being added. Nothing about what reaches Zipkin moves.

### Why the trace span is not in `getSpans()` until you call `trace()`

`addTraceSpan()` builds the span describing the trace itself using `zipkin_timestamp()` as its *end* time, at the moment `trace()` runs. Before that the end timestamp does not exist, so there is nothing truthful to return. Building it lazily inside `getSpans()` would mint a different span on every call and leave `trace()` appending a second one — two root spans in the trace. This is documented on the getter and pinned by a test.

### Behaviour changes worth knowing

- **Spans are now serialized late.** Anything changed on a `Span` after `addSpan()` ends up in the trace. The one that will actually bite people: a `Metadata` instance shared between spans is mutable (`Metadata::set()` appends), so every span sharing it reports the full accumulated set of `binaryAnnotations` rather than a snapshot from when it was added. Documented on `addSpan()` and in the README.
- **`addSpan()` rejects anything that is not a `Span`.** Serialization used to happen at the call site, so a bad argument failed there; deferring it would have moved that failure into `trace()`. This does reject duck-typed objects that only implement `toArray()` — an accident of the old implementation, never the documented contract (`@param $span Span`).
- **The element type of the `protected $spans` property changed** from arrays to `Span[]`, which matters to anyone subclassing `Tracer` and reading it directly.

### Noted, not fixed

Calling `trace()` twice appends the trace span twice. That is pre-existing behaviour, unrelated to this change, and left alone rather than widening scope.

### Tests

`tests/TracerTestCase.php` and `tests/TracerProxyTestCase.php` are new — `Tracer` had no direct coverage. A `SpyLogger` test double captures what `trace()` hands to the logger.

- added spans come back from `getSpans()`
- `trace()` sends serialized arrays to the logger
- the trace span is appended by `trace()`, not before
- nothing is collected when the trace is not sampled
- a non-`Span` argument throws

The two tests covering pre-existing behaviour (sampling, trace span) were confirmed to fail when that behaviour is removed, so they are real guards rather than tests that pass vacuously.

Full suite green locally on PHP 8.5: 26 tests, 71 assertions. CI covers 5.3 → 8.5 plus the 32-bit job; the change uses no syntax beyond what 5.3 accepts.
