### PR TITLE
fix(tracer)!: honour the incoming X-B3-ParentSpanId

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ $tracer = new Tracer(
     $endpoint, // Your application meta-information
     $logger // Logger used to store/send traces
 );
-$tracer->setProfile(Tracer::FRONTEND);
 ```
 For back-end applications / microservices (Consumer of existing TraceId, SpanId and Sampled)
 ```php
@@ -98,7 +97,6 @@ $tracer = new Tracer(
     $traceId,
     $traceSpanId
 );
-$tracer->setProfile(Tracer::BACKEND);
 ```
 
 All these lines must be initialized as soon as possible, in frameworks bootstrap.php is good place.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,25 @@ $ composer require whitemerry/phpkin
 ```
 
 ## Upgrading to 2.0
-`Tracer` used to serialize each `Span` the moment it was added. It now keeps the `Span` objects and serializes them once, in `trace()`, which is what makes `getSpans()` possible. What Zipkin receives is unchanged, but three things behave differently.
+`Tracer` used to serialize each `Span` the moment it was added. It now keeps the `Span` objects and serializes them once, in `trace()`, which is what makes `getSpans()` possible. What Zipkin receives is unchanged, but five things behave differently.
+
+#### The trace span is parented to its caller
+A back-end application used to give its trace span its own SpanId as the ParentId, so the span came out as its own parent and the caller propagated in `X-B3-ParentSpanId` was ignored. That header is now the seventh `Tracer` argument and links the span to its caller:
+```php
+$tracer = new Tracer($name, $endpoint, $logger, $isSampled, $traceId, $traceSpanId, $parentSpanId);
+```
+Leave it `null` and the span stays a root, which is what a front-end application wants.
+
+`Tracer::setProfile()`, `Tracer::FRONTEND` and `Tracer::BACKEND` are gone, because whether the span has a parent now follows from `$parentSpanId` alone. Drop the call; it fails at bootstrap rather than quietly doing nothing, which is the point - an application that kept calling it without passing `$parentSpanId` would go from self-parented spans to root spans with nothing to show anything had changed.
+
+#### Identifiers reject an invalid string
+`SpanIdentifier` and `TraceIdentifier` used to generate a fresh random identifier when handed something that was not a valid one, so a malformed B3 header produced a span attached to an id that had never existed. They now throw `InvalidArgumentException`:
+```php
+new SpanIdentifier('garbage');            // throws in 2.0, was a random identifier in 1.x
+new SpanIdentifier();                     // still generates one
+new SpanIdentifier('');                   // still generates one - an absent header reads as ''
+```
+Guard anything coming from a header with `is_zipkin_span_identifier()` / `is_zipkin_trace_identifier()`, as the back-end example below does.
 
 #### `addSpan()` only accepts `Span`
 Passing anything else throws `InvalidArgumentException`. Serialization used to happen inside `addSpan()`, so any object with a `toArray()` method quietly worked:
@@ -64,7 +82,8 @@ $logger = new SimpleHttpLogger([
 ```
 ***Now you can initialize Tracer!***
 
-For front-end applications (Source for TraceId, SpanId and Sampled for other microservices):
+For front-end applications (Source for TraceId, SpanId and Sampled for other microservices) there is nothing to
+consume, so the tracer generates the identifiers itself and starts the trace:
 ```php
 $tracer = new Tracer(
     'http://localhost/login', // Trace name
@@ -72,16 +91,22 @@ $tracer = new Tracer(
     $logger // Logger used to store/send traces
 );
 ```
-For back-end applications / microservices (Consumer of existing TraceId, SpanId and Sampled)
+For back-end applications / microservices (Consumer of existing TraceId, SpanId, ParentSpanId and Sampled) read the
+B3 headers the caller sent you and hand them to the tracer:
 ```php
 $traceId = null;
-if (!empty($_SERVER['HTTP_X_B3_TRACEID'])) {
+if (!empty($_SERVER['HTTP_X_B3_TRACEID']) && is_zipkin_trace_identifier($_SERVER['HTTP_X_B3_TRACEID'])) {
     $traceId = new TraceIdentifier($_SERVER['HTTP_X_B3_TRACEID']);
 }
 
 $traceSpanId = null;
-if (!empty($_SERVER['HTTP_X_B3_SPANID'])) {
+if (!empty($_SERVER['HTTP_X_B3_SPANID']) && is_zipkin_span_identifier($_SERVER['HTTP_X_B3_SPANID'])) {
     $traceSpanId = new SpanIdentifier($_SERVER['HTTP_X_B3_SPANID']);
+}
+
+$parentSpanId = null;
+if (!empty($_SERVER['HTTP_X_B3_PARENTSPANID']) && is_zipkin_span_identifier($_SERVER['HTTP_X_B3_PARENTSPANID'])) {
+    $parentSpanId = new SpanIdentifier($_SERVER['HTTP_X_B3_PARENTSPANID']);
 }
 
 $isSampled = null;
@@ -93,11 +118,29 @@ $tracer = new Tracer(
     'http://localhost/login',
     $endpoint,
     $logger,
-    $sampled,
+    $isSampled,
     $traceId,
-    $traceSpanId
+    $traceSpanId,
+    $parentSpanId
 );
 ```
+
+The three identifiers play different roles, and mixing them up is the easiest way to end up with a broken trace:
+
+| Argument | Header | Meaning |
+| --- | --- | --- |
+| `$traceId` | `X-B3-TraceId` | The whole trace, shared by every service taking part in it |
+| `$traceSpanId` | `X-B3-SpanId` | This request's own span |
+| `$parentSpanId` | `X-B3-ParentSpanId` | The caller's span, the one this request hangs under |
+
+***Keep the validity checks.*** Headers arrive from outside your application, and `SpanIdentifier` and
+`TraceIdentifier` throw on anything that is not a valid identifier. Guarding with `is_zipkin_span_identifier()` /
+`is_zipkin_trace_identifier()` means a broken - or hostile - caller costs you the link to that caller rather than the
+request itself.
+
+Leave `$parentSpanId` as `null` whenever no traced caller propagated one, and the trace starts at your application.
+A front-end taking a request straight from a browser is the usual case - something called you, but it was not part of
+the trace and sent no B3 headers. A cron job or a queue consumer works the same way.
 
 All these lines must be initialized as soon as possible, in frameworks bootstrap.php is good place.
 
@@ -124,7 +167,8 @@ $spanIdentifier = new SpanIdentifier();
 Request logic
 Remember, you need to add B3 headers to your request:
 X-B3-TraceId = TracerInfo::getTraceId();
-X-B3-SpanId = $spanIdentifier;
+X-B3-SpanId = $spanIdentifier;              // The span you just created for this call
+X-B3-ParentSpanId = TracerInfo::getTraceSpanId(); // Your own span, the parent of that call
 X-B3-Sampled = TracerInfo::isSampled();
 */
 
@@ -179,9 +223,11 @@ TracerProxy::trace();
 All meta information are in static class TracerInfo
 ```php
 TracerInfo::getTraceId(); // TraceId - X-B3-TraceId
-TracerInfo::getTraceSpanId(); // ParentId - X-B3-ParentId
+TracerInfo::getTraceSpanId(); // This request's own SpanId - X-B3-SpanId
 TracerInfo::isSampled(); // Sampled - X-B3-Sampled
 ```
+`getTraceSpanId()` returns the span of *this* request, not its parent. When you call another service it becomes that
+service's `X-B3-ParentSpanId`, which is where the name confusion tends to come from.
 
 #### Making requests to other service
 Take a look at our [examples](https://github.com/whitemerry/phpkin/tree/master/example). You need to set B3 header by your own in yours rest/api/guzzle client.
@@ -198,12 +244,6 @@ For more info read [this ticket](https://github.com/whitemerry/phpkin/issues/2)!
 For SimpleHttpLogger, short answer, ***yes***
 
 For FileLogger, bit logner answer, you need to upload logs from *zipkin.log* to Zipkin by your own, for example by cron working in background making POST's to the [Zipkin (API)](http://zipkin.io/zipkin-api/#/paths/%252Fspans/post)
-
-## Unit tests
-Code Coverage (Generated by PHPUnit):
-- Lines: 70.35% (140 / 199)
-- Functions and Methods: 52.08% (25 / 48)
-- Classes and Traits: 58.33% (7 / 12)
 
 ## TODO
 - AsyncHttpLogger (Based on CURL)

--- a/example/backend/index.php
+++ b/example/backend/index.php
@@ -31,13 +31,18 @@ $logger = new SimpleHttpLogger(array('host' => 'http://127.0.0.1:9411', 'muteErr
  * Read headers
  */
 $traceId = null;
-if (!empty($_SERVER['HTTP_X_B3_TRACEID'])) {
+if (!empty($_SERVER['HTTP_X_B3_TRACEID']) && is_zipkin_trace_identifier($_SERVER['HTTP_X_B3_TRACEID'])) {
     $traceId = new TraceIdentifier($_SERVER['HTTP_X_B3_TRACEID']);
 }
 
 $traceSpanId = null;
-if (!empty($_SERVER['HTTP_X_B3_SPANID'])) {
+if (!empty($_SERVER['HTTP_X_B3_SPANID']) && is_zipkin_span_identifier($_SERVER['HTTP_X_B3_SPANID'])) {
     $traceSpanId = new SpanIdentifier($_SERVER['HTTP_X_B3_SPANID']);
+}
+
+$parentSpanId = null;
+if (!empty($_SERVER['HTTP_X_B3_PARENTSPANID']) && is_zipkin_span_identifier($_SERVER['HTTP_X_B3_PARENTSPANID'])) {
+    $parentSpanId = new SpanIdentifier($_SERVER['HTTP_X_B3_PARENTSPANID']);
 }
 
 $isSampled = null;
@@ -49,7 +54,15 @@ if (!empty($_SERVER['HTTP_X_B3_SAMPLED'])) {
  * And create tracer object, if you want to have statically access just initialize TracerProxy
  * TracerProxy::init($tracer);
  */
-$tracer = new Tracer('backend get /index.php', $endpoint, $logger, $isSampled, $traceId, $traceSpanId);
+$tracer = new Tracer(
+    'backend get /index.php',
+    $endpoint,
+    $logger,
+    $isSampled,
+    $traceId,
+    $traceSpanId,
+    $parentSpanId
+);
 
 /**
  * Here is place for your application logic, we are making request to example REST API

--- a/example/backend/index.php
+++ b/example/backend/index.php
@@ -50,7 +50,6 @@ if (!empty($_SERVER['HTTP_X_B3_SAMPLED'])) {
  * TracerProxy::init($tracer);
  */
 $tracer = new Tracer('backend get /index.php', $endpoint, $logger, $isSampled, $traceId, $traceSpanId);
-$tracer->setProfile(Tracer::BACKEND);
 
 /**
  * Here is place for your application logic, we are making request to example REST API

--- a/src/Identifier/SpanIdentifier.php
+++ b/src/Identifier/SpanIdentifier.php
@@ -12,15 +12,25 @@ class SpanIdentifier extends Identifier
     /**
      * @inheritdoc
      *
+     * Generates an identifier when given nothing. An absent B3 header reaches
+     * $_SERVER as an empty string, so that counts as nothing too.
+     *
      * @param $fromString string Optional, creates identifier from string
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct($fromString = null)
     {
-        if ($fromString && is_zipkin_span_identifier($fromString)) {
-            $this->value = $fromString;
-        } else {
+        if ($fromString === null || $fromString === '') {
             parent::__construct();
+            return;
         }
+
+        if (!is_zipkin_span_identifier($fromString)) {
+            throw new \InvalidArgumentException('$fromString must be a valid span identifier');
+        }
+
+        $this->value = $fromString;
     }
 
     /**

--- a/src/Identifier/TraceIdentifier.php
+++ b/src/Identifier/TraceIdentifier.php
@@ -12,15 +12,25 @@ class TraceIdentifier extends Identifier
     /**
      * @inheritdoc
      *
+     * Generates an identifier when given nothing. An absent B3 header reaches
+     * $_SERVER as an empty string, so that counts as nothing too.
+     *
      * @param $fromString string Optional, creates identifier from string
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct($fromString = null)
     {
-        if ($fromString && is_zipkin_trace_identifier($fromString)) {
-            $this->value = $fromString;
-        } else {
+        if ($fromString === null || $fromString === '') {
             parent::__construct();
+            return;
         }
+
+        if (!is_zipkin_trace_identifier($fromString)) {
+            throw new \InvalidArgumentException('$fromString must be a valid trace identifier');
+        }
+
+        $this->value = $fromString;
     }
 
     /**

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -13,9 +13,6 @@ use whitemerry\phpkin\Sampler\Sampler;
  */
 class Tracer
 {
-    const FRONTEND = 'frontend';
-    const BACKEND = 'backend';
-
     /**
      * @var string
      */
@@ -40,11 +37,6 @@ class Tracer
      * @var Span[]
      */
     protected $spans = array();
-
-    /**
-     * @var string
-     */
-    protected $profile = Tracer::FRONTEND;
 
     /**
      * @var Identifier|null
@@ -82,16 +74,6 @@ class Tracer
         $this->startTimestamp = zipkin_timestamp();
 
         $this->parentSpanId = $parentSpanId;
-    }
-
-    /**
-     * Set's application profile
-     *
-     * @param $profile string Tracer::FRONTEND or Tracer::BACKEND
-     */
-    public function setProfile($profile)
-    {
-        $this->profile = $profile;
     }
 
     /**

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -47,21 +47,31 @@ class Tracer
     protected $profile = Tracer::FRONTEND;
 
     /**
-     * @var bool
+     * @var Identifier|null
      */
-    protected $unsetParentIdForBackend = false;
+    protected $parentSpanId;
 
     /**
      * Tracer constructor.
-     * 
+     *
      * @param $name string Name of trace
      * @param $endpoint Endpoint Current application info
      * @param $logger Logger Trace save handler
      * @param $sampler bool|Sampler Set or calculate 'Sampled' - default true
-     * @param $traceId Identifier TraceId - default TraceIdentifier
-     * @param $traceSpanId Identifier TraceSpanId/ParentSpanId/ParentId - default SpandIdentifier
+     * @param $traceId Identifier TraceId - X-B3-TraceId - default TraceIdentifier
+     * @param $traceSpanId Identifier SpanId of this request - X-B3-SpanId - default SpanIdentifier
+     * @param $parentSpanId Identifier ParentSpanId of the caller - X-B3-ParentSpanId,
+     *                      null when this application starts the trace
      */
-    public function __construct($name, $endpoint, $logger, $sampler = null, $traceId = null, $traceSpanId = null)
+    public function __construct(
+        $name,
+        $endpoint,
+        $logger,
+        $sampler = null,
+        $traceId = null,
+        $traceSpanId = null,
+        $parentSpanId = null
+    )
     {
         TracerInfo::init($sampler, $traceId, $traceSpanId);
 
@@ -71,7 +81,7 @@ class Tracer
 
         $this->startTimestamp = zipkin_timestamp();
 
-        $this->unsetParentIdForBackend = $traceSpanId === null;
+        $this->parentSpanId = $parentSpanId;
     }
 
     /**
@@ -131,12 +141,7 @@ class Tracer
             return;
         }
 
-        $unsetParentId = true;
-        if ($this->profile === static::BACKEND && !$this->unsetParentIdForBackend) {
-            $unsetParentId = false;
-        }
-
-        $this->addTraceSpan($unsetParentId);
+        $this->addTraceSpan();
         $this->logger->trace($this->spansToArray());
     }
 
@@ -158,9 +163,12 @@ class Tracer
     /**
      * Adds main span to Spans
      *
-     * @param $unsetParentId bool are you frontend?
+     * The span is parented to the caller's span when one was propagated through
+     * X-B3-ParentSpanId, otherwise this application starts the trace and the span
+     * is a root. Span defaults ParentId to the current SpanId, which would make the
+     * span its own parent, so it is always set explicitly here.
      */
-    protected function addTraceSpan($unsetParentId = true)
+    protected function addTraceSpan()
     {
         $span = new Span(
             TracerInfo::getTraceSpanId(),
@@ -170,11 +178,16 @@ class Tracer
                 $this->startTimestamp,
                 zipkin_timestamp(),
                 AnnotationBlock::SERVER
-            )
+            ),
+            null,
+            null,
+            $this->parentSpanId
         );
-        if ($unsetParentId) {
+
+        if ($this->parentSpanId === null) {
             $span->unsetParentId();
         }
+
         $this->addSpan($span);
     }
 

--- a/src/TracerInfo.php
+++ b/src/TracerInfo.php
@@ -33,8 +33,8 @@ class TracerInfo
 
     /**
      * @param $sampler bool|Sampler Set or calucate 'Sampled' - default true
-     * @param $traceId Identifier TraceId - default TraceIdentifier
-     * @param $traceSpanId Identifier TraceSpanId/ParentSpanId/ParentId - default SpandIdentifier
+     * @param $traceId Identifier TraceId - X-B3-TraceId - default TraceIdentifier
+     * @param $traceSpanId Identifier SpanId of this request - X-B3-SpanId - default SpanIdentifier
      */
     public static function init($sampler, $traceId, $traceSpanId)
     {
@@ -68,8 +68,11 @@ class TracerInfo
     }
 
     /**
-     * Current ParentSpanId/ParentId for X-B3-ParentSpanId
+     * Current SpanId for X-B3-SpanId
      * http://zipkin.io/pages/instrumenting.html#communicating-trace-information
+     *
+     * This is the id of this request's own span. When calling another service it
+     * becomes that service's X-B3-ParentSpanId.
      *
      * @return Identifier
      */

--- a/tests/IdentifierTestCase.php
+++ b/tests/IdentifierTestCase.php
@@ -10,8 +10,11 @@ use whitemerry\phpkin\Identifier\TraceIdentifier;
  * @author Piotr Bugaj <whitemerry@outlook.com>
  * @package whitemerry\phpkin\tests
  */
-class IdentifierTestCase extends \PHPUnit\Framework\TestCase
+class IdentifierTestCase extends TestCase
 {
+    const TRACE_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const SPAN_ID = 'bbbbbbbbbbbbbbbb';
+
     /**
      * @test
      */
@@ -35,6 +38,84 @@ class IdentifierTestCase extends \PHPUnit\Framework\TestCase
 
         // then
         $this->assertTrue(ctype_xdigit((string) $identifier));
+        $this->assertSame(16, strlen((string) $identifier));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateTraceIdentifierFromString()
+    {
+        // when
+        $identifier = new TraceIdentifier(static::TRACE_ID);
+
+        // then
+        $this->assertSame(static::TRACE_ID, (string) $identifier);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateSpanIdentifierFromString()
+    {
+        // when
+        $identifier = new SpanIdentifier(static::SPAN_ID);
+
+        // then
+        $this->assertSame(static::SPAN_ID, (string) $identifier);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldFailOnInvalidTraceIdentifier()
+    {
+        // then
+        $this->expectExceptionWithMessage('InvalidArgumentException', '$fromString');
+
+        // when
+        new TraceIdentifier('plaster');
+    }
+
+    /**
+     * @test
+     */
+    public function shouldFailOnInvalidSpanIdentifier()
+    {
+        // then
+        $this->expectExceptionWithMessage('InvalidArgumentException', '$fromString');
+
+        // when
+        new SpanIdentifier('plaster');
+    }
+
+    /**
+     * A span identifier is not a valid trace identifier is not a span identifier,
+     * so the lengths are not interchangeable
+     *
+     * @test
+     */
+    public function shouldFailOnSpanIdentifierOfTraceIdentifierLength()
+    {
+        // then
+        $this->expectExceptionWithMessage('InvalidArgumentException', '$fromString');
+
+        // when
+        new SpanIdentifier(static::TRACE_ID);
+    }
+
+    /**
+     * An absent B3 header reaches $_SERVER as an empty string, which means
+     * 'nobody told us', not 'here is a broken identifier'
+     *
+     * @test
+     */
+    public function shouldGenerateSpanIdentifierWhenGivenEmptyString()
+    {
+        // when
+        $identifier = new SpanIdentifier('');
+
+        // then
         $this->assertSame(16, strlen((string) $identifier));
     }
 }

--- a/tests/TracerTestCase.php
+++ b/tests/TracerTestCase.php
@@ -1,6 +1,8 @@
 <?php
 namespace whitemerry\phpkin\tests;
 
+use whitemerry\phpkin\Identifier\SpanIdentifier;
+use whitemerry\phpkin\Identifier\TraceIdentifier;
 use whitemerry\phpkin\Span;
 use whitemerry\phpkin\Tracer;
 
@@ -12,6 +14,10 @@ use whitemerry\phpkin\Tracer;
  */
 class TracerTestCase extends TestCase
 {
+    const TRACE_ID = 'aaaaaaaaaaaaaaaa';
+    const TRACE_SPAN_ID = 'bbbbbbbbbbbbbbbb';
+    const PARENT_SPAN_ID = 'cccccccccccccccc';
+
     /**
      * @test
      */
@@ -115,5 +121,147 @@ class TracerTestCase extends TestCase
 
         // then
         $tracer->addSpan('plaster');
+    }
+
+    /**
+     * @test
+     */
+    public function shouldTraceRootSpanWhenNothingPropagated()
+    {
+        // given
+        $logger = new SpyLogger();
+        $tracer = new Tracer('hut', Mocker::getEndpoint(), $logger);
+
+        // when
+        $tracer->trace();
+
+        // then
+        $this->assertArrayNotHasKey('parentId', $this->getTraceSpan($logger));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldParentTraceSpanToPropagatedParentSpanId()
+    {
+        // given
+        $logger = new SpyLogger();
+        $tracer = new Tracer(
+            'hut',
+            Mocker::getEndpoint(),
+            $logger,
+            true,
+            new TraceIdentifier(static::TRACE_ID),
+            new SpanIdentifier(static::TRACE_SPAN_ID),
+            new SpanIdentifier(static::PARENT_SPAN_ID)
+        );
+        $tracer->setProfile(Tracer::BACKEND);
+
+        // when
+        $tracer->trace();
+
+        // then
+        $traceSpan = $this->getTraceSpan($logger);
+        $this->assertSame(static::TRACE_ID, $traceSpan['traceId']);
+        $this->assertSame(static::TRACE_SPAN_ID, $traceSpan['id']);
+        $this->assertSame(static::PARENT_SPAN_ID, $traceSpan['parentId']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldTraceRootSpanWhenParentSpanIdMissing()
+    {
+        // given
+        $logger = new SpyLogger();
+        $tracer = new Tracer(
+            'hut',
+            Mocker::getEndpoint(),
+            $logger,
+            true,
+            new TraceIdentifier(static::TRACE_ID),
+            new SpanIdentifier(static::TRACE_SPAN_ID)
+        );
+        $tracer->setProfile(Tracer::BACKEND);
+
+        // when
+        $tracer->trace();
+
+        // then
+        $this->assertArrayNotHasKey('parentId', $this->getTraceSpan($logger));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNeverMakeTraceSpanItsOwnParent()
+    {
+        // given
+        $logger = new SpyLogger();
+        $tracer = new Tracer(
+            'hut',
+            Mocker::getEndpoint(),
+            $logger,
+            true,
+            new TraceIdentifier(static::TRACE_ID),
+            new SpanIdentifier(static::TRACE_SPAN_ID)
+        );
+        // The deprecated backend profile is what the self-parenting was reported
+        // under, so it stays here to prove it cannot bring the behaviour back
+        $tracer->setProfile(Tracer::BACKEND);
+
+        // when
+        $tracer->trace();
+
+        // then
+        $traceSpan = $this->getTraceSpan($logger);
+        $this->assertFalse(
+            isset($traceSpan['parentId']) && $traceSpan['parentId'] === $traceSpan['id'],
+            'Trace span must not reference itself as its own parent'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldParentAddedSpansToTraceSpan()
+    {
+        // given
+        $logger = new SpyLogger();
+        $tracer = new Tracer(
+            'hut',
+            Mocker::getEndpoint(),
+            $logger,
+            true,
+            new TraceIdentifier(static::TRACE_ID),
+            new SpanIdentifier(static::TRACE_SPAN_ID),
+            new SpanIdentifier(static::PARENT_SPAN_ID)
+        );
+        $tracer->addSpan(new Span(
+            Mocker::getIdentifier(),
+            'plaster',
+            Mocker::getAnnotationBlock()
+        ));
+
+        // when
+        $tracer->trace();
+
+        // then
+        $traced = $logger->getTracedSpans();
+        $this->assertSame(static::TRACE_SPAN_ID, $traced[0]['parentId']);
+    }
+
+    /**
+     * Span Tracer builds for the request itself, appended last by trace()
+     *
+     * @param $logger SpyLogger
+     *
+     * @return array
+     */
+    protected function getTraceSpan($logger)
+    {
+        $traced = $logger->getTracedSpans();
+
+        return $traced[count($traced) - 1];
     }
 }

--- a/tests/TracerTestCase.php
+++ b/tests/TracerTestCase.php
@@ -155,7 +155,6 @@ class TracerTestCase extends TestCase
             new SpanIdentifier(static::TRACE_SPAN_ID),
             new SpanIdentifier(static::PARENT_SPAN_ID)
         );
-        $tracer->setProfile(Tracer::BACKEND);
 
         // when
         $tracer->trace();
@@ -182,7 +181,6 @@ class TracerTestCase extends TestCase
             new TraceIdentifier(static::TRACE_ID),
             new SpanIdentifier(static::TRACE_SPAN_ID)
         );
-        $tracer->setProfile(Tracer::BACKEND);
 
         // when
         $tracer->trace();
@@ -206,9 +204,6 @@ class TracerTestCase extends TestCase
             new TraceIdentifier(static::TRACE_ID),
             new SpanIdentifier(static::TRACE_SPAN_ID)
         );
-        // The deprecated backend profile is what the self-parenting was reported
-        // under, so it stays here to prove it cannot bring the behaviour back
-        $tracer->setProfile(Tracer::BACKEND);
 
         // when
         $tracer->trace();


### PR DESCRIPTION
Closes #21
Closes #10

## The scenario

A back-end application receives a request carrying B3 headers. Per the spec its server span should be `traceId` = `X-B3-TraceId`, `id` = `X-B3-SpanId`, `parentId` = `X-B3-ParentSpanId`.

phpkin never read `X-B3-ParentSpanId`. `Tracer::addTraceSpan()` built the span without a ParentId, so `Span` fell back to its default and took the ParentId from `TracerInfo::getTraceSpanId()` — the very id the span was created with. Running the README's back-end setup:

```
id       => bbbbbbbbbbbbbbbb   (X-B3-SpanId)
traceId  => aaaaaaaaaaaaaaaa
parentId => bbbbbbbbbbbbbbbb   <- itself; the propagated 'cccc…' dropped
```

Every back-end span was its own parent, leaving Zipkin a one-span cycle instead of a link to the caller. Front-end was unaffected because `unsetParentId()` nulls it there, which is why this stayed hidden. The naming is the root cause: `TracerInfo::$traceSpanId` was documented as *"TraceSpanId/ParentSpanId/ParentId"* and the README described `getTraceSpanId()` as the ParentId, so two distinct B3 concepts got collapsed into one field and the parent never got a home.

The send side was already right — `example/` emits `X-B3-ParentSpanId: TracerInfo::getTraceSpanId()`. Only the receive side was missing. #10 reports the same self-parenting span from the `Span` default side.

## The fix

The parent arrives as a seventh `Tracer` constructor argument, matching how TraceId and SpanId are already handed in, and is set on the span explicitly. The library does not read `$_SERVER` itself (the fork referenced in #21 did); the application reads the header, as it already does for TraceId and SpanId. When nothing is propagated the application starts the trace and the span stays a root.

| traceSpanId | parentSpanId | trace span |
| --- | --- | --- |
| — | — | root, no `parentId` (unchanged) |
| given | given | `id`=traceSpanId, `parentId`=parentSpanId |
| given | — | root, no `parentId` (was: its own parent) |
| given | same as traceSpanId | root, no `parentId` — a cycle is treated as no parent |
| — | given | generated `id`, `parentId`=parentSpanId — not guarded, see notes |

`$parentSpanId` is validated like the other arguments: anything but an `Identifier` or `null` throws `InvalidArgumentException` at construction, instead of failing inside `Span` at `trace()`.

Verified end to end by simulating a real hop through the documented flow:

```
frontend  GET /login     id=d48c71b9… parent=(root)
frontend  call backend   id=e642706d… parent=d48c71b9…
backend   GET /index.php id=e642706d… parent=d48c71b9…   <- was parent=e642706d… (itself)
```

## Two breaking changes ride along

**`setProfile()` and the profile constants are removed.** Parent linkage now follows from `$parentSpanId` alone, leaving the profile with nothing to decide. Keeping it as a no-op would be the worse option: an application that upgrades and keeps calling `setProfile(Tracer::BACKEND)` without passing `$parentSpanId` goes from self-parented spans to root spans with nothing to signal the change. Removing it fails at bootstrap instead, which is where the upgrade notes are needed. 2.0 is already breaking, and with the milestone preparing this project for archivization, deferring removal to 3.0 would defer it indefinitely.

**`SpanIdentifier` / `TraceIdentifier` reject an invalid string, the empty string included.** They used to generate a fresh random identifier when handed one, so a malformed B3 header produced a span attached to an id that had never existed — harder to notice than a missing trace, and impossible for the library to detect after the fact. They now throw `InvalidArgumentException`. Only `null` still means generate. An absent header has no `$_SERVER` key and arrives as `null`; an empty string means the header was sent empty, which is a broken caller.

That second one has a trade-off worth a look: headers are attacker-controllable, so an application that passes them through unguarded would now throw on hostile input rather than silently mistrace. The documented pattern guards with `is_zipkin_span_identifier()` / `is_zipkin_trace_identifier()` before constructing, which turns a broken caller into a missing link rather than a failed request — the README and example do this and say why. Verified both paths:

```
guarded   is_zipkin_span_identifier('garbage') -> null    -> span stays a root
unguarded new SpanIdentifier('garbage')        -> throws: $fromString must be a valid span identifier
```

If you would rather not have that exposure, the alternative is a `tryFrom()`-style factory returning null, so the safe path needs no guard at all. Happy to add it.

## Also fixed in the docs

The back-end example and README read `X-B3-Sampled` with `(bool)` behind `!empty()`. `'0'` is empty in PHP, so a caller that chose not to sample was sampled anyway. They now read `1`/`true` and `0`/`false` explicitly and leave anything else to the tracer; the outgoing header is sent as `(int)`.

## Notes for review

- **The trace span `Tracer` emits had no test coverage** before this, which is how a self-parenting span survived. The new cases fold into the `TracerTestCase` added on master, and `IdentifierTestCase` gains the string-construction cases that were never covered.
- Commits are ordered so the bug is reproduced before it is fixed: the trace-span tests fail against the old code, the fix makes them pass, and `setProfile` is removed afterwards as now-dead API.
- A `$parentSpanId` passed without `$traceSpanId` is accepted and hangs a generated span under that parent. The fork has the same gap; the documented pattern reads all headers together, so it was left as is rather than guessed at.
- The stale hand-maintained coverage numbers are dropped from the README rather than guessed at; they will need a regen before release.
